### PR TITLE
Include Documentation References in Summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ The system allows agents to learn from user corrections and explanations, store 
 - **`README.md`** - User-facing documentation (installation, usage, examples)
 - **`docs/spec.md`** - Complete technical specification (see below)
 - **`command/`** - Command implementation files (the core of the system)
+  - These are implementation files containing agent instructions
+  - Not documentation files themselves, but operational directives
+  - Each file corresponds to a specific learning command
 
 ## Technical Specification
 

--- a/command/learning-improve-docs.md
+++ b/command/learning-improve-docs.md
@@ -4,13 +4,14 @@ description: Analyze learnings and suggest documentation improvements
 
 You are analyzing accumulated learnings to identify opportunities for improving project documentation.
 
-**Prerequisite**: This assumes `/learning-recall` has been run, giving you access to consolidated learnings.
+**Prerequisite**: This assumes `/learning-recall` has been run, giving you access to consolidated learnings and documentation references from recent sessions.
 
 ## Process
 
-1. **Find docs**: Look for README.md, CONTRIBUTING.md, AGENTS.md/CLAUDE.md, docs/, code comments, config files
-2. **Analyze gaps**: For each learning, check if documented; if not, identify best location
-3. **Present findings**: For each gap, show:
+1. **Review session documentation**: Check "Documentation Seen" fields in recent sessions to identify frequently-accessed docs
+2. **Find docs**: Look for README.md, CONTRIBUTING.md, AGENTS.md/CLAUDE.md, docs/, code comments, config files
+3. **Analyze gaps**: For each learning, check if documented; prioritize docs that were seen in the session where the learning originated
+4. **Present findings**: For each gap, show:
 
 ```markdown
 ## Documentation Improvement Opportunities
@@ -19,6 +20,7 @@ Based on [X] learnings, found [Y] documentation gaps:
 
 ### 1. [Brief description]
 **Learning**: [Specific undocumented learning]
+**Related Session Docs**: [If this learning came from a session that saw specific docs]
 **Location**: `path/to/file.md` (section: [Name])
 **Value**: [Why this matters]
 **Suggested Addition**:
@@ -41,6 +43,12 @@ Good documentation updates:
 - Are clear, concise, and actionable
 - Match project style and are properly located
 - Focus on project-specific knowledge
+- Prioritize improvements to frequently-accessed documentation (based on "Documentation Seen" in sessions)
+
+Priority hints:
+- Docs seen when learning was generated get highest priority
+- Frequently-seen docs across multiple sessions are good candidates
+- Consider the connection: learnings often highlight gaps in the exact docs the agent was reading
 
 Edge cases: No docs → suggest creating; Many gaps → prioritize top 5-10
 

--- a/command/learning-store.md
+++ b/command/learning-store.md
@@ -18,6 +18,7 @@ Ensure: User approved learnings via `/learning-summarise`, no sensitive data inc
 ```markdown
 ## [timestamp] - [Session Focus]
 **Project**: [project-name]
+**Documentation Seen**: [Brief list of doc locations from session]
 
 ### Learnings
 [Categorized learnings by type]
@@ -26,7 +27,14 @@ Ensure: User approved learnings via `/learning-summarise`, no sensitive data inc
 ```
 
 5. Write updated content back to file
-6. Confirm: "✓ Learnings stored in .tmp/memory-learnings.md"
+6. Confirm: "✓ Learnings stored in .tmp/memory-learnings.md with documentation references"
+
+## Documentation References
+
+Keep brief, just list locations like:
+- `README.md, CONTRIBUTING.md`
+- `docstrings in lib/foo.ex, lib/bar.ex`
+- `docs/api.md, docs/conventions.md`
 
 ## Error Handling
 

--- a/command/learning-summarise.md
+++ b/command/learning-summarise.md
@@ -10,14 +10,19 @@ You are extracting NEW knowledge from this session that would be valuable in fut
    - Use project documentation already in your context (from @mentions/exploration)
    - Read previous learnings from `.tmp/memory-learnings.md` if it exists
 
-2. **Identify NEW learnings** - Focus ONLY on:
+2. **Track documentation seen**:
+   - Note references to documentation encountered in this session
+   - Include: @mentioned files, explored docs, files with docstrings examined
+   - Keep brief: just file paths/locations (e.g., "docstrings in `lib/foo.ex`", "conventions in `docs/ui.md`")
+
+3. **Identify NEW learnings** - Focus ONLY on:
    - User corrections ("No, actually it should be...")
    - New requirements not in existing documentation
    - Updated conventions or pattern changes
    - Fresh discoveries and solutions from this session
    - User workflow/style preferences
 
-3. **Exclude**: Duplicates, general best practices, obvious codebase info
+4. **Exclude**: Duplicates, general best practices, obvious codebase info
 
 ## Output Format
 
@@ -29,9 +34,10 @@ For each NEW learning:
 
 Present findings showing:
 1. What existing knowledge sources you checked
-2. Only genuinely NEW learnings
-3. Ask for validation: accuracy, missing info, session-specific exclusions
+2. Documentation seen in this session (brief list of locations)
+3. Only genuinely NEW learnings
+4. Ask for validation: accuracy, missing info, session-specific exclusions
 
-Then inform: "If you're happy with these NEW learnings, you can save them using `/learning-store`"
+Then inform: "If you're happy with these NEW learnings and documentation references, you can save them using `/learning-store`"
 
 **Important**: Do NOT invoke `/learning-store` yourself. If no new learnings found, say so without suggesting storage.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -137,12 +137,15 @@ The memory file uses a specific markdown structure:
   
   ## [YYYY-MM-DD HH:MM TZ] - [Session Focus]
   **Project**: [project-name]
+  **Documentation Seen**: [Brief list of doc locations from session]
   
   ### Learnings
   [Categorized learning entries]
   
   ---
   ```
+
+The "Documentation Seen" field tracks references to documentation encountered during the session (e.g., "README.md, docstrings in lib/auth.ex, docs/api.md"). This helps identify which documentation is most relevant to the learnings generated.
 
 ### Learning Categories
 
@@ -206,21 +209,24 @@ Additional commands:
 
 ### `/learning-summarise`
 
-**Purpose**: Extract NEW learnings from current session while avoiding duplicates
+**Purpose**: Extract NEW learnings from current session while avoiding duplicates and tracking documentation seen
 
 **Behavior**:
 
 - Must use documentation already in agent context (from @mentions or exploration)
 - Must read previous learnings from `.tmp/memory-learnings.md`
+- Track references to documentation encountered in session (files, docstrings, conventions)
 - Filter potential learnings against existing knowledge base (context + previous learnings)
 - Present only genuinely new or updated information
 - Show deduplication work performed for transparency
+- Include list of documentation seen for future reference
 - Handle "no new learnings" case gracefully
 - Scales efficiently on large projects by not reading all documentation
 
 #### Performance and Scaling Considerations
 
 The `/learning-summarise` command is designed to scale efficiently on large projects by:
+
 - Using documentation already in the agent's context (from @mentions or exploration)
 - Avoiding exhaustive reading of all project documentation files
 - Focusing deduplication on agent context + previous learnings only
@@ -237,12 +243,13 @@ This approach prevents performance degradation as project size grows while maint
 
 ### `/learning-store`
 
-**Purpose**: Save validated learnings to memory file
+**Purpose**: Save validated learnings and documentation references to memory file
 
 **Behavior**:
 
 - Append to `.tmp/memory-learnings.md` with local timestamp and session focus
-- Include project name and session focus
+- Include project name, session focus, and documentation seen
+- Store brief references to documentation encountered (paths/locations only)
 - Organize learnings by category
 - Maintain reverse chronological order
 - Handle file creation if it doesn't exist
@@ -279,9 +286,12 @@ This approach prevents performance degradation as project size grows while maint
 
 - Assumes `/learning-recall` has been run first
 - Analyze consolidated learnings for documentation gaps
+- Review "Documentation Seen" fields from recent sessions
+- Prioritize improvements to documentation that was frequently accessed
+- Connect learnings to the specific docs seen when they were generated
 - Suggest specific files and sections for improvements
 - Provide example content for documentation updates
-- Prioritize most valuable improvements
+- Prioritize most valuable improvements based on usage patterns
 
 ### `/learning-forget`
 
@@ -300,6 +310,36 @@ Commands must handle common edge cases:
 - **Parse Errors**: Skip malformed sections, report what was successfully loaded
 - **Large Files**: Warn when approaching or exceeding 1MB limit
 - **No New Content**: Handle gracefully without unnecessary operations
+
+## Documentation Tracking System
+
+### Purpose
+
+Track which documentation was seen during learning sessions to better target documentation improvements.
+
+### What Constitutes "Documentation"
+
+Documentation includes any form of structured knowledge in the project:
+
+- **Source code docstrings**: Module and function documentation in code files
+- **Documentation files**: README.md, CONTRIBUTING.md, files in docs/ directories
+- **Specification files**: API specs, technical specifications, design documents
+- **Agent convention files**: AGENTS.md, CLAUDE.md, .cursorrules, or similar AI assistant guidance files
+- **Configuration documentation**: Comments in config files, setup guides
+
+### Implementation
+
+- **Session Tracking**: Record references to documentation encountered during each session
+- **Brief References**: Store only paths/locations, not content (e.g., "docstrings in lib/auth.ex")
+- **Connection Analysis**: Link learnings to the documentation seen when they were generated
+- **Prioritization**: Use tracking data to prioritize improvements to frequently-accessed documentation
+
+### Benefits
+
+- **Targeted Improvements**: Focus on documentation that agents actually use
+- **Context Awareness**: Understand which docs relate to specific learnings
+- **Efficiency**: Identify high-impact documentation gaps based on usage patterns
+- **Delta Recognition**: Recognize that learnings often represent gaps in the exact documentation the agent was reading
 
 ## Deduplication System
 
@@ -341,4 +381,3 @@ Prevent repetitive learnings that reduce memory quality over time.
 - **Markdown Format**: For structured data storage
 - **YAML**: For command frontmatter
 - **Local Time Format**: For human-readable timestamps with timezone
-

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -327,6 +327,12 @@ Documentation includes any form of structured knowledge in the project:
 - **Agent convention files**: AGENTS.md, CLAUDE.md, .cursorrules, or similar AI assistant guidance files
 - **Configuration documentation**: Comments in config files, setup guides
 
+### Storage Strategy
+
+- **Brief References Only**: Store only file paths and locations (e.g., "lib/auth.ex:45", "README.md#usage")
+- **No Content Storage**: Never store actual documentation content to keep memory files lean
+- **Performance Focus**: This approach ensures memory files remain manageable even in large projects
+
 ### Implementation
 
 - **Session Tracking**: Record references to documentation encountered during each session
@@ -340,6 +346,10 @@ Documentation includes any form of structured knowledge in the project:
 - **Context Awareness**: Understand which docs relate to specific learnings
 - **Efficiency**: Identify high-impact documentation gaps based on usage patterns
 - **Delta Recognition**: Recognize that learnings often represent gaps in the exact documentation the agent was reading
+- **Feedback Loop Architecture**: Creates a direct connection between learnings and their source documentation
+  - Enables identification of documentation that frequently generates learnings
+  - Highlights documentation sections that may need improvement
+  - Provides data-driven prioritization for documentation updates
 
 ## Deduplication System
 


### PR DESCRIPTION
I think this will make for a tight feedback loop, where the `/learning-improve-docs` command can see which bits of documentation were seen in sessions where new information was learned.